### PR TITLE
Enable 'PS2_DISC'-Feature

### DIFF
--- a/flags.h
+++ b/flags.h
@@ -23,7 +23,7 @@
 #define SPOOF_CONSOLEID	1	// spoof idps/psid
 
 //// TEST FEATURES ////
-//#define PS2_DISC		1	// uncomment to support /mount.ps2 (mount ps2 game folder as /dev_ps2disc)
+#define PS2_DISC		1	// uncomment to support /mount.ps2 (mount ps2 game folder as /dev_ps2disc)
 //#define NOSINGSTAR	1	// remove SingStar icon from XMB
 //#define SWAP_KERNEL	1	// load custom lv2_kernel.self patching LV1 and soft rebooting (use /copy.ps3)
 //#define EXTRA_FEAT	1	// save XMB to bmp, eject disc holding SELECT on mount,


### PR DESCRIPTION
Code is working.
Tested on Rebug 4.75.1 with SingStar, for Disc-Change ingame a PS2-Disc(not sure if SingStar is required, only have SingStar for testing) is required to eject/insert it and cause game reaction.
Tested with BCES00614 as iso mounted from NTFS-drive with different PS2-Folders
